### PR TITLE
Add maximumApiRetry to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ npm install -g homebridge-tedee
                     "defaultLatchName": "Latch"
                 }
             ],
-            "updateInterval": 15
+            "updateInterval": 15,
+            "maximumApiRetry": 3
         }
     ]
 }
@@ -62,6 +63,8 @@ npm install -g homebridge-tedee
 **defaultLatchName** (optional): Lets you customize the name of the unlatch mechanism. Useful for the Alexa plugin, which does not detect changes of service names in HomeKit. Defaults to `Latch`.
 
 **updateInterval**: The interval in seconds at which the lock state is updated from the API. Defaults to `15` seconds.
+
+**maximumApiRetry**: The amount of attempts to call the Tedee API. Useful if you do not want to repeat failed lock/unlock/unlatch attempts after a long timeout delay. Defaults to `3` attempts (incl. initial one).
 
 ## Usage
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -78,6 +78,13 @@
                 "default": 15,
                 "placeholder": "15",
                 "description": "The interval in seconds at which the lock state is updated from the API."
+            },
+            "maximumApiRetry": {
+                "title": "Maximum amount of retries",
+                "type": "integer",
+                "default": 3,
+                "placeholder": 3,
+                "description": "The amount of attempts to call the Tedee API. Useful if you do not want to repeat failed lock/unlock/unlatch attempts after a long timeout delay."
             }
         }
     }

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -94,7 +94,7 @@ export class Platform extends HomebridgePlatform<Configuration> {
         this.configuration.maximumTokenRetry = 3;
         this.configuration.tokenRetryInterval = 2000;
         this.configuration.apiUri = 'https://api.tedee.com/api/v1.18';
-        this.configuration.maximumApiRetry = 3;
+        this.configuration.maximumApiRetry = this.configuration.maximumApiRetry || 3;
         this.configuration.apiRetryInterval = 5000;
         this.configuration.updateInterval = this.configuration.updateInterval || 15;
 


### PR DESCRIPTION
**Problem:**
I had an issue when an API call got delayed for ~25 minutes and then suddenly finally failed with error 401. Because of the retry implementation it then retried the API call and pulled the latch, 25 minutes after the initial request (so that was quite surprising actually).
<pre>[37m[4/26/2022, 7:36:05 PM] [39m[36m[TedeePlatform][39m [Doma] Pull spring via HomeKit requested.
[37m[4/26/2022, 7:36:14 PM] [39m[36m[TedeePlatform][39m [Doma] Waiting for pull spring operation to be completed.
[37m[4/26/2022, 7:36:15 PM] [39m[36m[TedeePlatform][39m [Doma] Waiting for pull spring operation to be completed.
[37m[4/26/2022, 7:36:16 PM] [39m[36m[TedeePlatform][39m [Doma] Waiting for pull spring operation to be completed.
{...many repetitions of the same "Waiting" log message...}
[37m[4/26/2022, 8:02:31 PM] [39m[36m[TedeePlatform][39m [33m[Doma] Error while pulling spring via API: Error: Request failed with status code 401[39m
[37m[4/26/2022, 8:02:37 PM] [39m[36m[TedeePlatform][39m [Doma] Waiting for pull spring operation to be completed.
[37m[4/26/2022, 8:02:37 PM] [39m[36m[TedeePlatform][39m [Doma] Pulled spring via API.</pre>

**Solution:**
To prevent this, ability to disable retries should be introduced and that is exactly what this merge request offers.

**How is it implemented:**
- Setting value of **maximumApiRetry** to **1** will effectively disable any possible retry attempts on unlock/lock/unlatch API calls.